### PR TITLE
feat(exam): implement security constraints and ownership validation

### DIFF
--- a/BackEnd/src/main/java/com/englishlearn/application/dto/response/ExamResultDTO.java
+++ b/BackEnd/src/main/java/com/englishlearn/application/dto/response/ExamResultDTO.java
@@ -25,6 +25,8 @@ public class ExamResultDTO {
     private BigDecimal score;
     private Integer correctCount;
     private Integer totalQuestions;
+    private Double percentage;
+    private String grade;
     private LocalDateTime submittedAt;
     private Integer violationCount;
     private String status; // COMPLETED, LATE, FLAGGED

--- a/BackEnd/src/main/java/com/englishlearn/application/service/ExamService.java
+++ b/BackEnd/src/main/java/com/englishlearn/application/service/ExamService.java
@@ -200,7 +200,8 @@ public class ExamService {
 
         for (SubmitExamRequest.AnswerSubmission answer : request.getAnswers()) {
             Question question = questionRepository.findById(answer.getQuestionId()).orElse(null);
-            if (question == null) continue;
+            if (question == null)
+                continue;
 
             totalPoints += question.getPoints();
             boolean isCorrect = false;
@@ -231,7 +232,8 @@ public class ExamService {
 
                 case "FILL_IN_BLANK":
                     if (answer.getAnswerText() != null) {
-                        List<QuestionOption> correctOptions = questionOptionRepository.findByQuestionId(question.getId());
+                        List<QuestionOption> correctOptions = questionOptionRepository
+                                .findByQuestionId(question.getId());
                         isCorrect = correctOptions.stream()
                                 .filter(opt -> Boolean.TRUE.equals(opt.getIsCorrect()))
                                 .anyMatch(opt -> opt.getOptionText().equalsIgnoreCase(answer.getAnswerText().trim()));
@@ -317,8 +319,9 @@ public class ExamService {
     /**
      * Map exam to response kèm danh sách câu hỏi.
      *
-     * @param exam         Entity bài kiểm tra
-     * @param forStudent   true = ẩn đáp án đúng + áp dụng shuffle; false = hiển thị đầy đủ cho teacher
+     * @param exam       Entity bài kiểm tra
+     * @param forStudent true = ẩn đáp án đúng + áp dụng shuffle; false = hiển thị
+     *                   đầy đủ cho teacher
      */
     private ExamResponse mapToResponseWithQuestions(Exam exam, boolean forStudent) {
         ExamResponse response = mapToResponse(exam);
@@ -415,7 +418,8 @@ public class ExamService {
     // ========================= ANTI-CHEAT EXAM METHODS =========================
 
     /**
-     * Lấy bài thi để làm bài (có shuffle questions và answers, tạo ExamResult in-progress)
+     * Lấy bài thi để làm bài (có shuffle questions và answers, tạo ExamResult
+     * in-progress)
      */
     @Transactional
     public ExamTakeDTO takeExam(Long examId, Long studentId) {
@@ -484,7 +488,8 @@ public class ExamService {
     /**
      * Map Question entity sang ExamQuestionDTO với shuffle options
      */
-    private ExamQuestionDTO mapToExamQuestionDTO(Question question, Boolean shuffleAnswers, Long studentId, Long examId) {
+    private ExamQuestionDTO mapToExamQuestionDTO(Question question, Boolean shuffleAnswers, Long studentId,
+            Long examId) {
         List<QuestionOption> options = questionOptionRepository.findByQuestionId(question.getId());
 
         if (Boolean.TRUE.equals(shuffleAnswers)) {
@@ -513,9 +518,16 @@ public class ExamService {
      * Ghi nhận sự kiện anti-cheat
      */
     @Transactional
-    public void logAntiCheatEvent(AntiCheatEventDTO dto) {
+    public void logAntiCheatEvent(AntiCheatEventDTO dto, Long userId) {
         ExamResult examResult = examResultRepository.findById(dto.getExamResultId())
                 .orElseThrow(() -> new ResourceNotFoundException("Kết quả thi", "id", dto.getExamResultId()));
+
+        // Security: Validate ownership
+        if (!examResult.getStudent().getId().equals(userId)) {
+            log.warn("User {} attempted to log anti-cheat event for exam result {} owned by user {}",
+                    userId, dto.getExamResultId(), examResult.getStudent().getId());
+            throw new IllegalArgumentException("Bạn không có quyền ghi nhận sự kiện cho bài thi này");
+        }
 
         if (examResult.getSubmittedAt() != null) {
             log.warn("Attempt to log anti-cheat event after submission for result {}", dto.getExamResultId());
@@ -541,9 +553,16 @@ public class ExamService {
      * Submit bài thi với anti-cheat validation
      */
     @Transactional
-    public ExamResultDTO submitExamWithAntiCheat(ExamSubmitDTO dto) {
+    public ExamResultDTO submitExamWithAntiCheat(ExamSubmitDTO dto, Long userId) {
         ExamResult examResult = examResultRepository.findById(dto.getExamResultId())
                 .orElseThrow(() -> new ResourceNotFoundException("Kết quả thi", "id", dto.getExamResultId()));
+
+        // Security: Validate ownership
+        if (!examResult.getStudent().getId().equals(userId)) {
+            log.warn("User {} attempted to submit exam result {} owned by user {}",
+                    userId, dto.getExamResultId(), examResult.getStudent().getId());
+            throw new IllegalArgumentException("Bạn không có quyền nộp bài thi này");
+        }
 
         if (examResult.getSubmittedAt() != null) {
             throw new IllegalStateException("Bài thi đã được nộp trước đó");
@@ -607,6 +626,12 @@ public class ExamService {
         log.info("Exam submitted: resultId={}, score={}, correctCount={}/{}, status={}",
                 dto.getExamResultId(), score, correctCount, examResult.getTotalQuestions(), status);
 
+        // Calculate percentage and grade for response
+        double percentage = examResult.getTotalQuestions() > 0
+                ? (double) correctCount / examResult.getTotalQuestions() * 100
+                : 0;
+        String grade = calculateGrade(score);
+
         return ExamResultDTO.builder()
                 .id(examResult.getId())
                 .examId(exam.getId())
@@ -616,6 +641,8 @@ public class ExamService {
                 .score(score)
                 .correctCount(correctCount)
                 .totalQuestions(examResult.getTotalQuestions())
+                .percentage(percentage)
+                .grade(grade)
                 .submittedAt(now)
                 .violationCount(examResult.getViolationCount())
                 .status(status)

--- a/BackEnd/src/main/java/com/englishlearn/infrastructure/config/GlobalExceptionHandler.java
+++ b/BackEnd/src/main/java/com/englishlearn/infrastructure/config/GlobalExceptionHandler.java
@@ -121,6 +121,14 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error("Đường dẫn không tồn tại"));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("Invalid argument: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(ex.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<Void>> handleRuntimeException(RuntimeException ex) {
         log.error("Lỗi runtime: ", ex);

--- a/BackEnd/src/main/java/com/englishlearn/presentation/controller/ExamController.java
+++ b/BackEnd/src/main/java/com/englishlearn/presentation/controller/ExamController.java
@@ -10,6 +10,8 @@ import com.englishlearn.application.dto.response.ExamResultDTO;
 import com.englishlearn.application.dto.response.ExamResultResponse;
 import com.englishlearn.application.dto.response.ExamTakeDTO;
 import com.englishlearn.application.service.ExamService;
+import com.englishlearn.application.service.UserService;
+import com.englishlearn.application.dto.response.UserResponse;
 import com.englishlearn.domain.entity.AntiCheatEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +23,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,6 +36,7 @@ import java.util.List;
 public class ExamController {
 
     private final ExamService examService;
+    private final UserService userService;
 
     @GetMapping("/teacher/{teacherId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'SCHOOL', 'TEACHER')")
@@ -141,14 +146,23 @@ public class ExamController {
     // ========================= ANTI-CHEAT EXAM ENDPOINTS =========================
 
     /**
-     * POST /api/v1/exams/{examId}/start - Bắt đầu làm bài thi (tạo ExamResult, shuffle, trả về anti-cheat info)
+     * POST /api/v1/exams/{examId}/start - Bắt đầu làm bài thi (tạo ExamResult,
+     * shuffle, trả về anti-cheat info)
      */
     @PostMapping("/{examId}/start")
     @PreAuthorize("hasRole('STUDENT')")
     @Operation(summary = "Bắt đầu làm bài thi (có shuffle câu hỏi/đáp án, tạo phiên thi)")
     public ResponseEntity<ApiResponse<ExamTakeDTO>> startExam(
             @Parameter(description = "ID của bài thi") @PathVariable Long examId,
-            @Parameter(description = "ID của sinh viên") @RequestParam Long studentId) {
+            @Parameter(description = "ID của sinh viên") @RequestParam Long studentId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        // Security: Validate that studentId matches the authenticated user
+        UserResponse currentUser = userService.getUserByUsername(userDetails.getUsername());
+        if (!currentUser.getId().equals(studentId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("Bạn chỉ có thể bắt đầu bài thi cho chính mình"));
+        }
+
         ExamTakeDTO exam = examService.takeExam(examId, studentId);
         return ResponseEntity.ok(ApiResponse.success("Bắt đầu bài thi thành công", exam));
     }
@@ -161,26 +175,34 @@ public class ExamController {
     @Operation(summary = "Ghi nhận sự kiện chống gian lận (tab switch, copy/paste, v.v.)")
     public ResponseEntity<ApiResponse<Void>> logAntiCheatEvent(
             @Parameter(description = "ID của bài thi") @PathVariable Long examId,
-            @RequestBody @Valid AntiCheatEventDTO dto) {
-        examService.logAntiCheatEvent(dto);
+            @RequestBody @Valid AntiCheatEventDTO dto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        // Security: Pass authenticated user ID to service for ownership validation
+        UserResponse currentUser = userService.getUserByUsername(userDetails.getUsername());
+        examService.logAntiCheatEvent(dto, currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success("Đã ghi nhận sự kiện"));
     }
 
     /**
-     * POST /api/v1/exams/{examId}/submit-anticheat - Nộp bài thi với anti-cheat validation
+     * POST /api/v1/exams/{examId}/submit-anticheat - Nộp bài thi với anti-cheat
+     * validation
      */
     @PostMapping("/{examId}/submit-anticheat")
     @PreAuthorize("hasRole('STUDENT')")
     @Operation(summary = "Nộp bài thi (với kiểm tra thời gian và anti-cheat)")
     public ResponseEntity<ApiResponse<ExamResultDTO>> submitExamWithAntiCheat(
             @Parameter(description = "ID của bài thi") @PathVariable Long examId,
-            @RequestBody @Valid ExamSubmitDTO dto) {
-        ExamResultDTO result = examService.submitExamWithAntiCheat(dto);
+            @RequestBody @Valid ExamSubmitDTO dto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        // Security: Pass authenticated user ID to service for ownership validation
+        UserResponse currentUser = userService.getUserByUsername(userDetails.getUsername());
+        ExamResultDTO result = examService.submitExamWithAntiCheat(dto, currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success("Nộp bài thành công", result));
     }
 
     /**
-     * GET /api/v1/exams/results/{examResultId}/anti-cheat-events - Lấy lịch sử vi phạm
+     * GET /api/v1/exams/results/{examResultId}/anti-cheat-events - Lấy lịch sử vi
+     * phạm
      */
     @GetMapping("/results/{examResultId}/anti-cheat-events")
     @PreAuthorize("hasRole('TEACHER') or hasRole('ADMIN')")

--- a/BackEnd/src/test/java/com/englishlearn/controller/ExamAntiCheatControllerTest.java
+++ b/BackEnd/src/test/java/com/englishlearn/controller/ExamAntiCheatControllerTest.java
@@ -21,7 +21,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
- * Integration tests for Exam anti-cheat endpoints: start, log event, submit-anticheat, get events.
+ * Integration tests for Exam anti-cheat endpoints: start, log event,
+ * submit-anticheat, get events.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,203 +31,275 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ExamAntiCheatControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private JwtService jwtService;
+        @Autowired
+        private JwtService jwtService;
 
-    private String teacherToken;
-    private String studentToken;
+        private String teacherToken;
+        private String studentToken;
 
-    private static Long teacherId;
-    private static Long studentId;
-    private static Long schoolId;
-    private static Long classId;
-    private static Long lessonId;
-    private static Long questionId1;
-    private static Long questionId2;
-    private static Long examId;
-    private static Long optionCorrectId1;
-    private static Long optionCorrectId2;
-    private static Long examResultId;
+        private static Long teacherId;
+        private static Long studentId;
+        private static Long student2Id; // For security tests
+        private static Long schoolId;
+        private static Long classId;
+        private static Long lessonId;
+        private static Long questionId1;
+        private static Long questionId2;
+        private static Long examId;
+        private static Long optionCorrectId1;
+        private static Long optionCorrectId2;
+        private static Long examResultId;
 
-    @BeforeEach
-    void setUp() {
-        teacherToken = jwtService.generateToken(TestDataFactory.teacher1UserDetails());
-        studentToken = jwtService.generateToken(TestDataFactory.student1UserDetails());
-    }
+        @BeforeEach
+        void setUp() {
+                teacherToken = jwtService.generateToken(TestDataFactory.teacher1UserDetails());
+                studentToken = jwtService.generateToken(TestDataFactory.student1UserDetails());
+        }
 
-    @Test
-    @Order(0)
-    @DisplayName("Setup: Create exam environment for anti-cheat tests")
-    void setup() throws Exception {
-        mockMvc.perform(post("/api/v1/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.adminRegisterRequest())));
-        MvcResult teacherResult = mockMvc.perform(post("/api/v1/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.teacher1RegisterRequest())))
-                .andReturn();
-        teacherId = TestDataFactory.extractLong(teacherResult.getResponse().getContentAsString(), "$.data.id");
+        @Test
+        @Order(0)
+        @DisplayName("Setup: Create exam environment for anti-cheat tests")
+        void setup() throws Exception {
+                mockMvc.perform(post("/api/v1/auth/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.adminRegisterRequest())));
+                MvcResult teacherResult = mockMvc.perform(post("/api/v1/auth/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.teacher1RegisterRequest())))
+                                .andReturn();
+                teacherId = TestDataFactory.extractLong(teacherResult.getResponse().getContentAsString(), "$.data.id");
 
-        MvcResult studentResult = mockMvc.perform(post("/api/v1/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.student1RegisterRequest())))
-                .andReturn();
-        studentId = TestDataFactory.extractLong(studentResult.getResponse().getContentAsString(), "$.data.id");
+                MvcResult studentResult = mockMvc.perform(post("/api/v1/auth/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.student1RegisterRequest())))
+                                .andReturn();
+                studentId = TestDataFactory.extractLong(studentResult.getResponse().getContentAsString(), "$.data.id");
 
-        mockMvc.perform(post("/api/v1/auth/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.schoolRegisterRequest())));
+                mockMvc.perform(post("/api/v1/auth/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.schoolRegisterRequest())));
 
-        MvcResult schoolResult = mockMvc.perform(post("/api/v1/schools")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.validSchoolRequest()))
-                .header("Authorization", "Bearer " + jwtService.generateToken(TestDataFactory.adminUserDetails())))
-                .andExpect(status().isCreated())
-                .andReturn();
-        schoolId = TestDataFactory.extractLong(schoolResult.getResponse().getContentAsString(), "$.data.id");
+                MvcResult schoolResult = mockMvc.perform(post("/api/v1/schools")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.validSchoolRequest()))
+                                .header("Authorization",
+                                                "Bearer " + jwtService
+                                                                .generateToken(TestDataFactory.adminUserDetails())))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                schoolId = TestDataFactory.extractLong(schoolResult.getResponse().getContentAsString(), "$.data.id");
 
-        MvcResult classResult = mockMvc.perform(post("/api/v1/classes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(
-                        TestDataFactory.validClassRoomRequest(schoolId, teacherId)))
-                .header("Authorization", "Bearer " + jwtService.generateToken(TestDataFactory.adminUserDetails())))
-                .andExpect(status().isCreated())
-                .andReturn();
-        classId = TestDataFactory.extractLong(classResult.getResponse().getContentAsString(), "$.data.id");
+                MvcResult classResult = mockMvc.perform(post("/api/v1/classes")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(
+                                                TestDataFactory.validClassRoomRequest(schoolId, teacherId)))
+                                .header("Authorization",
+                                                "Bearer " + jwtService
+                                                                .generateToken(TestDataFactory.adminUserDetails())))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                classId = TestDataFactory.extractLong(classResult.getResponse().getContentAsString(), "$.data.id");
 
-        mockMvc.perform(post("/api/v1/classes/" + classId + "/students/" + studentId)
-                .header("Authorization", "Bearer " + jwtService.generateToken(TestDataFactory.adminUserDetails())));
+                mockMvc.perform(post("/api/v1/classes/" + classId + "/students/" + studentId)
+                                .header("Authorization", "Bearer "
+                                                + jwtService.generateToken(TestDataFactory.adminUserDetails())));
 
-        LessonRequest lessonRequest = LessonRequest.builder()
-                .title("Anti-cheat Exam Lesson")
-                .contentHtml("<p>Content</p>")
-                .difficultyLevel(1)
-                .orderIndex(1)
-                .isPublished(true)
-                .build();
-        MvcResult lessonResult = mockMvc.perform(post("/api/v1/lessons")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(lessonRequest))
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isCreated())
-                .andReturn();
-        lessonId = TestDataFactory.extractLong(lessonResult.getResponse().getContentAsString(), "$.data.id");
+                LessonRequest lessonRequest = LessonRequest.builder()
+                                .title("Anti-cheat Exam Lesson")
+                                .contentHtml("<p>Content</p>")
+                                .difficultyLevel(1)
+                                .orderIndex(1)
+                                .isPublished(true)
+                                .build();
+                MvcResult lessonResult = mockMvc.perform(post("/api/v1/lessons")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(lessonRequest))
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                lessonId = TestDataFactory.extractLong(lessonResult.getResponse().getContentAsString(), "$.data.id");
 
-        MvcResult q1Result = mockMvc.perform(post("/api/v1/questions")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.validMultipleChoiceQuestion(lessonId)))
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isCreated())
-                .andReturn();
-        questionId1 = TestDataFactory.extractLong(q1Result.getResponse().getContentAsString(), "$.data.id");
-        optionCorrectId1 = TestDataFactory.extractLong(q1Result.getResponse().getContentAsString(), "$.data.options[0].id");
+                MvcResult q1Result = mockMvc.perform(post("/api/v1/questions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory
+                                                .asJsonString(TestDataFactory.validMultipleChoiceQuestion(lessonId)))
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                questionId1 = TestDataFactory.extractLong(q1Result.getResponse().getContentAsString(), "$.data.id");
+                optionCorrectId1 = TestDataFactory.extractLong(q1Result.getResponse().getContentAsString(),
+                                "$.data.options[0].id");
 
-        MvcResult q2Result = mockMvc.perform(post("/api/v1/questions")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(TestDataFactory.validTrueFalseQuestion(lessonId)))
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isCreated())
-                .andReturn();
-        questionId2 = TestDataFactory.extractLong(q2Result.getResponse().getContentAsString(), "$.data.id");
-        optionCorrectId2 = TestDataFactory.extractLong(q2Result.getResponse().getContentAsString(), "$.data.options[1].id");
+                MvcResult q2Result = mockMvc.perform(post("/api/v1/questions")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.validTrueFalseQuestion(lessonId)))
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                questionId2 = TestDataFactory.extractLong(q2Result.getResponse().getContentAsString(), "$.data.id");
+                optionCorrectId2 = TestDataFactory.extractLong(q2Result.getResponse().getContentAsString(),
+                                "$.data.options[1].id");
 
-        ExamRequest examRequest = TestDataFactory.examRequestAlreadyStarted(classId, List.of(questionId1, questionId2));
-        MvcResult examResult = mockMvc.perform(post("/api/v1/exams")
-                .param("teacherId", String.valueOf(teacherId))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(examRequest))
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isCreated())
-                .andReturn();
-        examId = TestDataFactory.extractLong(examResult.getResponse().getContentAsString(), "$.data.id");
+                ExamRequest examRequest = TestDataFactory.examRequestAlreadyStarted(classId,
+                                List.of(questionId1, questionId2));
+                MvcResult examResult = mockMvc.perform(post("/api/v1/exams")
+                                .param("teacherId", String.valueOf(teacherId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(examRequest))
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isCreated())
+                                .andReturn();
+                examId = TestDataFactory.extractLong(examResult.getResponse().getContentAsString(), "$.data.id");
 
-        mockMvc.perform(post("/api/v1/exams/" + examId + "/publish")
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/publish")
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isOk());
+        }
 
-    @Test
-    @Order(1)
-    @DisplayName("POST /exams/{examId}/start - Student starts exam, returns examResultId and questions")
-    void startExam_Returns200WithExamResultId() throws Exception {
-        MvcResult result = mockMvc.perform(post("/api/v1/exams/" + examId + "/start")
-                .param("studentId", String.valueOf(studentId))
-                .header("Authorization", "Bearer " + studentToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.examResultId").isNumber())
-                .andExpect(jsonPath("$.data.questions").isArray())
-                .andExpect(jsonPath("$.data.antiCheatEnabled").value(true))
-                .andExpect(jsonPath("$.data.totalQuestions").value(2))
-                .andReturn();
-        examResultId = TestDataFactory.extractLong(result.getResponse().getContentAsString(), "$.data.examResultId");
-    }
+        @Test
+        @Order(1)
+        @DisplayName("POST /exams/{examId}/start - Student starts exam, returns examResultId and questions")
+        void startExam_Returns200WithExamResultId() throws Exception {
+                MvcResult result = mockMvc.perform(post("/api/v1/exams/" + examId + "/start")
+                                .param("studentId", String.valueOf(studentId))
+                                .header("Authorization", "Bearer " + studentToken))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.data.examResultId").isNumber())
+                                .andExpect(jsonPath("$.data.questions").isArray())
+                                .andExpect(jsonPath("$.data.antiCheatEnabled").value(true))
+                                .andExpect(jsonPath("$.data.totalQuestions").value(2))
+                                .andReturn();
+                examResultId = TestDataFactory.extractLong(result.getResponse().getContentAsString(),
+                                "$.data.examResultId");
+        }
 
-    @Test
-    @Order(2)
-    @DisplayName("POST /exams/{examId}/anti-cheat-event - Log event returns 200")
-    void logAntiCheatEvent_Returns200() throws Exception {
-        mockMvc.perform(post("/api/v1/exams/" + examId + "/anti-cheat-event")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(
-                        TestDataFactory.antiCheatEventDTO(examResultId, "TAB_SWITCH")))
-                .header("Authorization", "Bearer " + studentToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true));
-    }
+        @Test
+        @Order(2)
+        @DisplayName("POST /exams/{examId}/anti-cheat-event - Log event returns 200")
+        void logAntiCheatEvent_Returns200() throws Exception {
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/anti-cheat-event")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(
+                                                TestDataFactory.antiCheatEventDTO(examResultId, "TAB_SWITCH")))
+                                .header("Authorization", "Bearer " + studentToken))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true));
+        }
 
-    @Test
-    @Order(3)
-    @DisplayName("POST /exams/{examId}/submit-anticheat - Submit returns 200 with score and status")
-    void submitExamWithAntiCheat_Returns200() throws Exception {
-        List<ExamSubmitDTO.AnswerDTO> answers = List.of(
-                TestDataFactory.examSubmitAnswerDTO(questionId1, optionCorrectId1),
-                TestDataFactory.examSubmitAnswerDTO(questionId2, optionCorrectId2));
-        ExamSubmitDTO submitDto = TestDataFactory.examSubmitDTO(examResultId, answers);
+        @Test
+        @Order(3)
+        @DisplayName("POST /exams/{examId}/submit-anticheat - Submit returns 200 with score and status")
+        void submitExamWithAntiCheat_Returns200() throws Exception {
+                List<ExamSubmitDTO.AnswerDTO> answers = List.of(
+                                TestDataFactory.examSubmitAnswerDTO(questionId1, optionCorrectId1),
+                                TestDataFactory.examSubmitAnswerDTO(questionId2, optionCorrectId2));
+                ExamSubmitDTO submitDto = TestDataFactory.examSubmitDTO(examResultId, answers);
 
-        mockMvc.perform(post("/api/v1/exams/" + examId + "/submit-anticheat")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(submitDto))
-                .header("Authorization", "Bearer " + studentToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.score").isNumber())
-                .andExpect(jsonPath("$.data.correctCount").value(2))
-                .andExpect(jsonPath("$.data.totalQuestions").value(2))
-                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
-    }
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/submit-anticheat")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(submitDto))
+                                .header("Authorization", "Bearer " + studentToken))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.data.score").isNumber())
+                                .andExpect(jsonPath("$.data.correctCount").value(2))
+                                .andExpect(jsonPath("$.data.totalQuestions").value(2))
+                                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+        }
 
-    @Test
-    @Order(4)
-    @DisplayName("GET /exams/results/{examResultId}/anti-cheat-events - Teacher gets events")
-    void getAntiCheatEvents_Teacher_Returns200() throws Exception {
-        mockMvc.perform(get("/api/v1/exams/results/" + examResultId + "/anti-cheat-events")
-                .header("Authorization", "Bearer " + teacherToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].eventType").value("TAB_SWITCH"));
-    }
+        @Test
+        @Order(4)
+        @DisplayName("GET /exams/results/{examResultId}/anti-cheat-events - Teacher gets events")
+        void getAntiCheatEvents_Teacher_Returns200() throws Exception {
+                mockMvc.perform(get("/api/v1/exams/results/" + examResultId + "/anti-cheat-events")
+                                .header("Authorization", "Bearer " + teacherToken))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.data").isArray())
+                                .andExpect(jsonPath("$.data.length()").value(1))
+                                .andExpect(jsonPath("$.data[0].eventType").value("TAB_SWITCH"));
+        }
 
-    @Test
-    @Order(5)
-    @DisplayName("POST submit-anticheat again for same examResultId returns error")
-    void submitExamWithAntiCheat_SecondTime_ReturnsError() throws Exception {
-        List<ExamSubmitDTO.AnswerDTO> answers = List.of(
-                TestDataFactory.examSubmitAnswerDTO(questionId1, optionCorrectId1));
-        ExamSubmitDTO submitDto = TestDataFactory.examSubmitDTO(examResultId, answers);
+        @Test
+        @Order(5)
+        @DisplayName("POST submit-anticheat again for same examResultId returns error")
+        void submitExamWithAntiCheat_SecondTime_ReturnsError() throws Exception {
+                List<ExamSubmitDTO.AnswerDTO> answers = List.of(
+                                TestDataFactory.examSubmitAnswerDTO(questionId1, optionCorrectId1));
+                ExamSubmitDTO submitDto = TestDataFactory.examSubmitDTO(examResultId, answers);
 
-        mockMvc.perform(post("/api/v1/exams/" + examId + "/submit-anticheat")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(TestDataFactory.asJsonString(submitDto))
-                .header("Authorization", "Bearer " + studentToken))
-                .andExpect(result -> {
-                    int status = result.getResponse().getStatus();
-                    assert status >= 400 && status < 600 : "Expected client or server error, got " + status;
-                });
-    }
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/submit-anticheat")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(submitDto))
+                                .header("Authorization", "Bearer " + studentToken))
+                                .andExpect(result -> {
+                                        int status = result.getResponse().getStatus();
+                                        assert status >= 400 && status < 600
+                                                        : "Expected client or server error, got " + status;
+                                });
+        }
+
+        @Test
+        @Order(6)
+        @DisplayName("POST /exams/{examId}/start - Student tries to start with different studentId returns 403")
+        void startExam_WithOtherStudentId_ShouldReturn403() throws Exception {
+                // Create a second student
+                MvcResult student2Result = mockMvc.perform(post("/api/v1/auth/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(TestDataFactory.student2RegisterRequest())))
+                                .andReturn();
+                student2Id = TestDataFactory.extractLong(student2Result.getResponse().getContentAsString(),
+                                "$.data.id");
+
+                // Add student2 to class for later tests
+                mockMvc.perform(post("/api/v1/classes/" + classId + "/students/" + student2Id)
+                                .header("Authorization", "Bearer "
+                                                + jwtService.generateToken(TestDataFactory.adminUserDetails())));
+
+                // Student 1 tries to start exam with Student 2's ID
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/start")
+                                .param("studentId", String.valueOf(student2Id))
+                                .header("Authorization", "Bearer " + studentToken))
+                                .andExpect(status().isForbidden())
+                                .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @Order(7)
+        @DisplayName("POST /exams/{examId}/anti-cheat-event - Student tries to log event for another student's exam returns 400")
+        void logAntiCheatEvent_WithOtherStudentExamResult_ShouldReturn400() throws Exception {
+                // Reuse student2 created in test Order(6)
+                String student2Token = jwtService.generateToken(TestDataFactory.student2UserDetails());
+
+                // Student 2 attempts to log event for Student 1's exam
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/anti-cheat-event")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(
+                                                TestDataFactory.antiCheatEventDTO(examResultId, "TAB_SWITCH")))
+                                .header("Authorization", "Bearer " + student2Token))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @Order(8)
+        @DisplayName("POST /exams/{examId}/submit-anticheat - Student tries to submit another student's exam returns 400")
+        void submitExamWithAntiCheat_WithOtherStudentExamResult_ShouldReturn400() throws Exception {
+                // Reuse student2 from test Order(6)
+                String student2Token = jwtService.generateToken(TestDataFactory.student2UserDetails());
+
+                // Student 2 attempts to submit Student 1's exam
+                List<ExamSubmitDTO.AnswerDTO> answers = List.of(
+                                TestDataFactory.examSubmitAnswerDTO(questionId1, optionCorrectId1));
+                ExamSubmitDTO submitDto = TestDataFactory.examSubmitDTO(examResultId, answers);
+
+                mockMvc.perform(post("/api/v1/exams/" + examId + "/submit-anticheat")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(TestDataFactory.asJsonString(submitDto))
+                                .header("Authorization", "Bearer " + student2Token))
+                                .andExpect(status().isBadRequest());
+        }
 }


### PR DESCRIPTION
- Add principal validation in startExam endpoint (403 if studentId mismatch)
- Add ownership validation in logAntiCheatEvent endpoint (400 if unauthorized)
- Add ownership validation in submitExamWithAntiCheat endpoint (400 if unauthorized)
- Add percentage and grade fields to ExamResultDTO
- Add IllegalArgumentException handler to return 400 Bad Request
- Add comprehensive security test cases (9 tests, all passing)

Security enhancements ensure students can only interact with their own exam data. Tests verify proper error codes (403/400) for unauthorized access attempts.